### PR TITLE
Feature/enum variants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ use uuid::Uuid;
 use serde::{Deserialize, Serialize};
 use web_sys::HtmlInputElement;
 
-
 //---------------------------------------
 //               Structs
 //---------------------------------------
@@ -40,6 +39,7 @@ struct TodoItem {
     completed: bool,
 }
 
+
 #[derive(Serialize, Deserialize)]
 struct EditingTodoItem {
     id: TodoItemId,
@@ -53,7 +53,26 @@ struct EditingTodoItem {
 
 #[derive(Clone)]
 enum Msg {
+    //~~~~~~~~~~~~~~
+    //  General
+    //~~~~~~~~~~~~~~
     //ChangeText(String),
+    NewTodoTitleUpdated(String),
+    ClearEntireTodoList,
+
+    //~~~~~~~~~~~~~~
+    //  SingleTodo
+    //~~~~~~~~~~~~~~
+    CreateNewTodoItem,
+    RemoveTodoItem(TodoItemId),
+
+    //~~~~~~~~~~~~~~
+    //  EditTodo
+    //~~~~~~~~~~~~~~
+    StartTodoEdit(TodoItemId),
+    EditingTodoTitleUpdated(String),
+    SaveEditingTodo,
+    CancelTodoEdit,
 }
 
 fn update(msg: Msg, model: &mut Model, _orders: &mut impl Orders<Msg>) {


### PR DESCRIPTION
**Enums Added and Match arms built out**
_In General_
- NewTodoTitleUpdated --- updates todo name
- ClearEntireTodoList  --- clears all tasks/todos

_Todo Specific_
- CreateNewTodoItem --- creates todo and adds it to the index map with uuid generated as id
- RemoveTodoItem --- removes selected todo item from todolist

_Editing Related_
- StartTodoEdit --- Selects and starts modifying a todo item title/name
- EditingTodoTitleUpdated ---updates the new input title
- SaveEditingTodo --- saves the input update changes
- CancelTodoEdit --- cancels the edit process